### PR TITLE
Decrement numberOfPreviewAssets by 1 for endIndex

### DIFF
--- a/ios/RNPhotosFramework/PHCollectionService.m
+++ b/ios/RNPhotosFramework/PHCollectionService.m
@@ -169,7 +169,7 @@ static id ObjectOrNull(id object)
                 }
                 
                 if(numberOfPreviewAssets > 0) {
-                   NSArray<NSDictionary *> *previewAssets = [PHAssetsService assetsArrayToUriArray:[PHAssetsService getAssetsForFetchResult:assets startIndex:0 endIndex:numberOfPreviewAssets] andIncludeMetaData:NO];
+                   NSArray<NSDictionary *> *previewAssets = [PHAssetsService assetsArrayToUriArray:[PHAssetsService getAssetsForFetchResult:assets startIndex:0 endIndex:(numberOfPreviewAssets-1)] andIncludeMetaData:NO];
                     [albumDictionary setObject:previewAssets forKey:@"previewAssets"];
                 }
                 


### PR DESCRIPTION
The numberOfPreviewAssets prop should be decremented by 1 when setting the endIndex in order to fetch the correct amount of previewAssets.  Currently, if the previewAssets prop is set to 1, you will receive two assets.  Decrementing the numberOfPreviewAssets by 1 when setting the endIndex seems to be a sufficient place to implement this change in order to achieve desired functionality of previewAssets.  I have tested this patch and am now receiving the correct amount of previewAssets.

Also, is it possible to set fetchOptions for previewAssets?  If not, I think this would be a useful feature to implement.  Setting fetchOptions for previewAssets would allow the developer to set mediaTypes if an album should only contains images or to customize sortDescriptors to receive the correct previewAsset.  I was thinking this could be done through a new "previewAssetFetchOptions" property that passes fetchOptions when setting previewAssets.  Can you think of an easy fix or way to implement this functionality?  I'd be happy to help implement.  

This is an awesome and incredibly useful project!  Well done so far!